### PR TITLE
Tab explicitly opened by "New Tab" button now opens next to the last tab

### DIFF
--- a/background.js
+++ b/background.js
@@ -74,6 +74,11 @@ function moveTab(newTab) {
                 return;
             }
 
+            if (newTab.url == 'about:newtab') {
+                // tab created by pressing "New Tab" button
+                return;
+            }
+
             if (browser.sessions.getTabValue && browser.sessions.setTabValue) {
                 browser.sessions.getTabValue(newTab.id, TAB_SESSION_KEY).then(
                     (uuid) => {

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,8 @@
     "manifest_version": 2,
     "name": "Open Tabs Next to Current",
     "permissions": [
-        "sessions"
+        "sessions",
+        "tabs"
     ],
     "version": "2.0.10"
 }


### PR DESCRIPTION
Fixes: https://github.com/sblask/webextension-open-tabs-next-to-current/issues/38